### PR TITLE
Updated to properly parse callables in [$class,$method] format.

### DIFF
--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -79,9 +79,9 @@ final class CallableResolver implements CallableResolverInterface
         }
 
         if (!is_callable($resolved)) {
-            throw new RuntimeException(sprintf('%s is not resolvable', $toResolve));
+            throw new RuntimeException(sprintf('%s is not resolvable', is_array($toResolve) || is_object($toResolve) ? json_encode($toResolve) : $toResolve));
         }
-
+        
         return $resolved;
     }
 }


### PR DESCRIPTION
When i used Slim3 with callables ['\App\Controller\Main','mainMethod'] (and similar) when there weren't class loaded, instead of proper error i was getting conversion array to string errors from previous line. This patch fixes the issue by json_encoding the callable before trying to sprintf %s it.